### PR TITLE
Make Builds populate there evars the same way the deploy does

### DIFF
--- a/api/exec.go
+++ b/api/exec.go
@@ -29,6 +29,7 @@ func (api *API) LibDirs(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (api *API) FileChange(rw http.ResponseWriter, req *http.Request) {
+	<- time.After(time.Second)
 	fs.Touch(req.FormValue("filename"))
 	writeBody(nil, rw, http.StatusOK)
 }


### PR DESCRIPTION
fixes #11 and fixes #12 by adding a sleep in the file touch, and uses the logic from the deploy for getting the evar's